### PR TITLE
chapter 6: repair tags link (were unclosed) 

### DIFF
--- a/book
+++ b/book
@@ -4517,7 +4517,7 @@ function like this:
 >       pieces.push(escapeHTML(element));
 >     }
 >     // Empty tag
->     else if (!element.content || element.content.length == 0) {
+>     else if (element.name != "a" && (!element.content || element.content.length == 0)) {
 >       pieces.push("<" + element.name +
 >                   renderAttributes(element.attributes) + "/>");
 >     }


### PR DESCRIPTION
On footnotes, the </a> closing tags were missing :

<p><small><a name=\"note1\"/>[1] This is not to be read as an encouragement of sloppy programming, but rather as a warning against neurotic adherence to rules of thumb.</small></p>
